### PR TITLE
Ensure that reference to watcher is kept

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 {{$NEXT}}
+	- Broken watch mode fixed (GitHub issue #108).
+
+0.10.0 - 2023-07-14
 	- Switch to AnyEvent::Filesys::Watcher:
 	  * support for MSWin32
 	  * less dependencies because not based on Moo

--- a/META.json
+++ b/META.json
@@ -134,7 +134,7 @@
          "web" : "http://github.com/gflohr/qgoda.git"
       }
    },
-   "version" : "v0.10.0",
+   "version" : "v0.10.1",
    "x_generated_by_perl" : "v5.34.0",
    "x_serialization_backend" : "Cpanel::JSON::XS version 4.26",
    "x_spdx_expression" : "GPL-3.0-only"

--- a/META.yml
+++ b/META.yml
@@ -104,7 +104,7 @@ resources:
   bugtracker: https://github.com/gflohr/qgoda/issues
   homepage: https://www.qgoda.net/
   repository: git://github.com/gflohr/qgoda.git
-version: v0.10.0
+version: v0.10.1
 x_generated_by_perl: v5.34.0
 x_serialization_backend: 'YAML::Tiny version 1.73'
 x_spdx_expression: GPL-3.0-only

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -269,7 +269,7 @@ my %WriteMakefileArgs = (
     "lib" => 0,
     "utf8" => 0
   },
-  "VERSION" => "v0.10.0",
+  "VERSION" => "v0.10.1",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/dist.ini
+++ b/dist.ini
@@ -22,9 +22,9 @@ copyright_year = 2016-2020
 
 ; We have to set the version number in lib/Qgoda/package.json.
 ; How can I refer to the value of the version above?
-version = v0.10.0
+version = v0.10.1
 [Substitute]
-code = s/"version": ".+"/"version": "0.10.0"/
+code = s/"version": ".+"/"version": "0.10.1"/
 file = lib/Qgoda/package.json
 [@Filter]
 -bundle = @Basic

--- a/lib/Qgoda.pm
+++ b/lib/Qgoda.pm
@@ -281,10 +281,11 @@ sub watch {
 
 		$logger->debug(__x("waiting for changes in '{dir}'",
 						   dir => $config->{srcdir}));
-		AnyEvent::Filesys::Watcher->new(
-			directories => $config->{srcdir},
+		my $watcher;
+		$watcher= AnyEvent::Filesys::Watcher->new(
+			dirs => [$config->{srcdir}],
 			interval => $config->{latency},
-			callback => sub { $self->__onFilesysChange(\%options, @_) },
+			cb => sub { $self->__onFilesysChange(\%options, @_) },
 			filter => sub { $self->__filesysChangeFilter(@_) },
 		);
 
@@ -847,8 +848,8 @@ sub __onFilesysChange {
 
 	foreach my $event (@events) {
 		$logger->info(__x("file '{filename}' has changed",
-						  filename => $event->{path}));
-		push @files, $event->{path};
+						  filename => $event->path));
+		push @files, $event->path;
 	}
 
 	return if !@files;

--- a/lib/Qgoda.pm
+++ b/lib/Qgoda.pm
@@ -21,7 +21,7 @@ package Qgoda;
 use strict;
 
 use version;
-our $VERSION = 'v0.10.0'; #VERSION
+our $VERSION = 'v0.10.1'; #VERSION
 
 # FIXME! This assumes that we are a top-level package. Instead,
 # inpect also __PACKAGE__ and adjust the directory accordingly.

--- a/lib/Qgoda/package.json
+++ b/lib/Qgoda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qgoda",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "The Qgoda Static Site Generator",
   "main": "index.js",
   "repository": "https://github.com/gflohr/qgoda",


### PR DESCRIPTION
AnyEvent::Filesys::Notify contained cyclic references.  It was therefore not necessary to keep a reference to the notifier object.  That has been fixed in AnyEvent::Filesys::Watcher but as a consequence one extra reference has to be created.

Fixes #108.