### PR TITLE
clean discount automatic links

### DIFF
--- a/lib/Qgoda/HTMLFilter/CleanUp.pm
+++ b/lib/Qgoda/HTMLFilter/CleanUp.pm
@@ -45,7 +45,8 @@ sub start {
 
 	if ('a' eq lc $args{tagname}
 	    && defined $args{attr}->{href}
-	    && $args{attr}->{href} =~ s/[!,.:;?]$//) {
+	    && $args{attr}->{href} =~ s/([!,.:;?])$//) {
+		$self->{__interpunction} = $1;
 		$chunk = '<' . $args{tagname};
 
 		my $attrseq = $args{attrseq};
@@ -65,6 +66,17 @@ sub start {
 	}
 
 	return $chunk;
+}
+
+sub end {
+	my ($self, $chunk, %args) = @_;
+
+	my $interpunction = delete $self->{__interpunction} // '';
+	if ('a' eq $args{tagname}) {
+		return $chunk . $interpunction;
+	} else {
+		return $interpunction . $chunk;
+	}
 }
 
 1;

--- a/lib/Qgoda/HTMLFilter/CleanUp.pm
+++ b/lib/Qgoda/HTMLFilter/CleanUp.pm
@@ -40,4 +40,31 @@ sub comment {
 	return '';
 }
 
+sub start {
+	my ($self, $chunk, %args) = @_;
+
+	if ('a' eq lc $args{tagname}
+	    && defined $args{attr}->{href}
+	    && $args{attr}->{href} =~ s/[!,.:;?]$//) {
+		$chunk = '<' . $args{tagname};
+
+		my $attrseq = $args{attrseq};
+		my $attr = $args{attr};
+		foreach my $key (@$attrseq) {
+			my $value = $attr->{$key};
+
+			my %escapes = (
+				'"' => '&quot;',
+				'&' => '&amp;'
+			);
+			$value =~ s/(["&])/$escapes{$1}/g;
+			$chunk .= qq{ $key="$value"};
+		}
+
+		$chunk .= '>';
+	}
+
+	return $chunk;
+}
+
 1;


### PR DESCRIPTION
Discount considers interpunction like full stops, exclamation marks and so on part of the href of the link.  Since this is almost always incorrect, we remove such trailing characters from all links.